### PR TITLE
Refactor/#40 oauth2 handler

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/member/controller/AuthController.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/controller/AuthController.java
@@ -1,9 +1,9 @@
 package com.dnd.jjakkak.domain.member.controller;
 
 import com.dnd.jjakkak.domain.member.jwt.provider.JwtProvider;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,8 +16,9 @@ import java.util.Collections;
  *
  * @author 류태웅
  * @version 2024. 08. 02.
+ *
  */
-
+@Slf4j
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
@@ -26,8 +27,8 @@ public class AuthController {
     private final JwtProvider jwtProvider;
 
     /**
-     * 로그아웃 시 프론트 측에서 보내는 access_token과 일치한 지 확인 후
-     * 프론트엔드에게 로그인 또는 비로그인 상태의 메세지롤 보냄
+     * 프론트 측에서 보내는 access_token을 확인 후
+     * 프론트엔드에게 로그인 또는 비로그인 상태의 메시지를 보냄
      *
      * @param request        HttpServletRequest
      * @return message ResponseEntity
@@ -35,18 +36,18 @@ public class AuthController {
 
     @GetMapping("/check-auth")
     public ResponseEntity<?> checkAuth(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookie.getName().equals("access_token")) {
-                    String token = cookie.getValue();
-                    if (!jwtProvider.validate(token).isEmpty()) {
-                        return ResponseEntity.ok().body(Collections.singletonMap("isAuthenticated", true));
-                    }
-                }
+        String authorizationHeader = request.getHeader("Authorization");
+        log.info(authorizationHeader);
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);
+            String subject = jwtProvider.validate(token);
+
+            if (subject != null && !subject.isEmpty()) {
+                log.info("isAuthenticated");
+                return ResponseEntity.ok().body(Collections.singletonMap("isAuthenticated", true));
             }
         }
+        log.info("isNotAuthenticated");
         return ResponseEntity.ok().body(Collections.singletonMap("isAuthenticated", false));
     }
 }
-

--- a/src/main/java/com/dnd/jjakkak/domain/member/controller/AuthController.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/controller/AuthController.java
@@ -1,87 +1,52 @@
 package com.dnd.jjakkak.domain.member.controller;
 
-import com.dnd.jjakkak.domain.member.service.BlacklistService;
-import com.dnd.jjakkak.domain.member.service.RefreshTokenService;
-import com.dnd.jjakkak.global.exception.ErrorResponse;
+import com.dnd.jjakkak.domain.member.jwt.provider.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
+import java.util.Collections;
 
 /**
- * 로그아웃 시 사용하는 컨트롤러입니다.
+ * 현재 Member의 로그인 여부를 확인하는 컨트롤러입니다.
  *
  * @author 류태웅
- * @version 2024. 07. 27.
+ * @version 2024. 08. 02.
  */
 
-@Slf4j
 @RestController
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class AuthController {
-    private final RefreshTokenService refreshTokenService;
-    private final BlacklistService blacklistService;
+
+    private final JwtProvider jwtProvider;
 
     /**
-     * 로그아웃을 할 때 사용합니다.
-     * 헤더에 Authorization : Bearer {refresh_token}을 입력한 다음 호출
-     * 그렇게 되면 DB에 refresh_token이 삭제되고 블랙리스트에 추가됨
+     * 로그아웃 시 프론트 측에서 보내는 access_token과 일치한 지 확인 후
+     * 프론트엔드에게 로그인 또는 비로그인 상태의 메세지롤 보냄
      *
-     * @param refreshToken String
-     * @return ResponseEntity<String>
+     * @param request        HttpServletRequest
+     * @return message ResponseEntity
      */
-    @PostMapping("/api/v1/logout")
-    public ResponseEntity<?> logout(@RequestHeader(value = "Authorization", required = false) String refreshToken) {
 
-        // TODO: LoginHandler로 수정해보기
-
-        log.info("logout 시작");
-
-        if (refreshToken != null && refreshToken.startsWith("Bearer ")) {
-            refreshToken = refreshToken.substring(7);
-            log.info("logout refreshToken: {}", refreshToken);
-
-            if (refreshTokenService.validateRefreshToken(refreshToken)) {
-                try {
-                    refreshTokenService.deleteRefreshToken(refreshToken);
-                    LocalDateTime expirationDate = LocalDateTime.now().plusWeeks(1); // 토큰의 실제 만료 시간으로 설정
-                    blacklistService.blacklistToken(refreshToken, expirationDate);
-                    log.info("logout 성공");
-                    return ResponseEntity.ok().build();
-                } catch (Exception e) {
-                    log.error("서버 에러", e);
-
-                    ErrorResponse response = ErrorResponse.builder()
-                            .code("500")
-                            .message("Server Error")
-                            .build();
-
-                    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    @GetMapping("/check-auth")
+    public ResponseEntity<?> checkAuth(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("access_token")) {
+                    String token = cookie.getValue();
+                    if (!jwtProvider.validate(token).isEmpty()) {
+                        return ResponseEntity.ok().body(Collections.singletonMap("isAuthenticated", true));
+                    }
                 }
-            } else {
-                log.error("Refresh Token 인증 오류");
-
-                ErrorResponse response = ErrorResponse.builder()
-                        .code("401")
-                        .message("Invalid Refresh Token")
-                        .build();
-
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
             }
         }
-
-        log.error("헤더 인증 오류");
-
-        ErrorResponse response = ErrorResponse.builder()
-                .code("400")
-                .message("Invalid Header Error")
-                .build();
-
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        return ResponseEntity.ok().body(Collections.singletonMap("isAuthenticated", false));
     }
 }
+

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/exception/AccessTokenExpiredException.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/exception/AccessTokenExpiredException.java
@@ -1,0 +1,16 @@
+package com.dnd.jjakkak.domain.member.jwt.exception;
+
+import com.dnd.jjakkak.global.exception.GeneralException;
+
+public class AccessTokenExpiredException extends GeneralException {
+    private static final String MESSAGE = "엑세스 토큰이 만료됨.";
+
+    public AccessTokenExpiredException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 401;
+    }
+}

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/exception/MalformedTokenException.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/exception/MalformedTokenException.java
@@ -1,0 +1,16 @@
+package com.dnd.jjakkak.domain.member.jwt.exception;
+
+import com.dnd.jjakkak.global.exception.GeneralException;
+
+public class MalformedTokenException extends GeneralException {
+    private static final String MESSAGE = "손상된 토큰.";
+
+    public MalformedTokenException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 401;
+    }
+}

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,8 @@ package com.dnd.jjakkak.domain.member.jwt.filter;
 import com.dnd.jjakkak.domain.member.entity.Member;
 import com.dnd.jjakkak.domain.member.entity.Role;
 import com.dnd.jjakkak.domain.member.exception.MemberNotFoundException;
+import com.dnd.jjakkak.domain.member.jwt.exception.AccessTokenExpiredException;
+import com.dnd.jjakkak.domain.member.jwt.exception.MalformedTokenException;
 import com.dnd.jjakkak.domain.member.jwt.provider.JwtProvider;
 import com.dnd.jjakkak.domain.member.repository.MemberRepository;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -31,7 +33,7 @@ import java.util.List;
 /**
  * 검증을 실행하는 필터입니다.
  * @author 류태웅
- * @version 2024. 08. 02.
+ * @version 2024. 08. 03.
  */
 
 @Slf4j
@@ -55,18 +57,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info("검증된 카카오 ID: {}", kakaoId);
         } catch (ExpiredJwtException e) {
             log.error("엑세스 토큰이 만료됨", e);
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-            response.getWriter().write("{\"error\": \"Token expired\"}");
-            response.getWriter().flush();
-            return;
+            throw new AccessTokenExpiredException();
         } catch (MalformedJwtException e) {
             log.error("손상된 토큰", e);
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-            response.getWriter().write("{\"error\": \"Malformed Token\"}");
-            response.getWriter().flush();
-            return;
+            throw new MalformedTokenException();
         }
 
         if (kakaoId == null) {

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/filter/JwtAuthenticationFilter.java
@@ -5,9 +5,7 @@ import com.dnd.jjakkak.domain.member.entity.Role;
 import com.dnd.jjakkak.domain.member.exception.MemberNotFoundException;
 import com.dnd.jjakkak.domain.member.jwt.provider.JwtProvider;
 import com.dnd.jjakkak.domain.member.repository.MemberRepository;
-import com.dnd.jjakkak.domain.member.service.RefreshTokenService;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -31,8 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * 권한과 인증 방식을 검사하는 필터입니다.
- *
+ * 검증을 실행하는 필터입니다.
  * @author 류태웅
  * @version 2024. 08. 02.
  */
@@ -43,47 +40,40 @@ import java.util.List;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
-    private final RefreshTokenService refreshTokenService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info("도착한 요청: {}", request.getRequestURI());
         String token = parseBearerToken(request);
         log.info("도착한 토큰: {}", token);
-
-        if (token == null) {
+        if (token == null) { // Bearer 인증 방식이 아니거나 빈 값일 경우 진행하지 말고 다음 필터로 바로 넘김
             filterChain.doFilter(request, response);
             return;
         }
-
-        String kakaoId = null;
+        String kakaoId;
         try {
             kakaoId = jwtProvider.validate(token);
             log.info("검증된 카카오 ID: {}", kakaoId);
         } catch (ExpiredJwtException e) {
             log.error("엑세스 토큰이 만료됨", e);
-            setErrorResponse(response, "Token expired");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\": \"Token expired\"}");
+            response.getWriter().flush();
             return;
         } catch (MalformedJwtException e) {
             log.error("손상된 토큰", e);
-            setErrorResponse(response, "Malformed Token");
-            return;
-        } catch (JwtException e) {
-            log.error("토큰 검증 오류", e);
-            setErrorResponse(response, "Invalid Token");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\": \"Malformed Token\"}");
+            response.getWriter().flush();
             return;
         }
 
         if (kakaoId == null) {
-            handleTokenException(response, request);
+            filterChain.doFilter(request, response);
             return;
         }
 
-        processAuthentication(kakaoId, request);
-        filterChain.doFilter(request, response);
-    }
-
-    private void processAuthentication(String kakaoId, HttpServletRequest request) {
         Member member = memberRepository.findByKakaoId(Long.parseLong(kakaoId))
                 .orElseThrow(MemberNotFoundException::new);
         Role role = member.getRole();
@@ -97,46 +87,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         securityContext.setAuthentication(authenticationToken);
         SecurityContextHolder.setContext(securityContext);
-    }
 
-    private void handleTokenException(HttpServletResponse response, HttpServletRequest request) throws IOException {
-        String refreshToken = parseRefreshToken(request);
-        log.info("도착한 리프레시 토큰: {}", refreshToken);
-
-        if (refreshToken != null && refreshTokenService.validateRefreshToken(refreshToken)) {
-            String kakaoId = jwtProvider.getSubjectFromRefreshToken(refreshToken);
-            String newToken = jwtProvider.createAccessToken(kakaoId);
-            response.setHeader("Authorization", "Bearer " + newToken);
-            log.info("새로 발급된 엑세스 토큰: {}", newToken);
-            processAuthentication(kakaoId, request);
-        } else {
-            log.error("엑세스 토큰이 만료되었고 해당되는 리프레시 토큰이 존재하지 않습니다.");
-            setErrorResponse(response, "Invalid Refresh Token");
-        }
-    }
-
-    private void setErrorResponse(HttpServletResponse response, String message) throws IOException {
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
-        response.getWriter().write("{\"error\": \"" + message + "\"}");
-        response.getWriter().flush();
+        filterChain.doFilter(request, response);
     }
 
     private String parseBearerToken(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
-
         if (StringUtils.hasText(authorization) && authorization.startsWith("Bearer ")) {
-            String token = authorization.substring(7);
-            if (!"undefined".equalsIgnoreCase(token)) {
-                return token;
-            }
+            return authorization.substring(7);
         }
-
         return null;
-    }
-
-    private String parseRefreshToken(HttpServletRequest request) {
-        String refreshToken = request.getHeader("RefreshToken");
-        return StringUtils.hasText(refreshToken) ? refreshToken : null;
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/filter/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import com.dnd.jjakkak.domain.member.jwt.provider.JwtProvider;
 import com.dnd.jjakkak.domain.member.repository.MemberRepository;
 import com.dnd.jjakkak.domain.member.service.RefreshTokenService;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -33,7 +34,7 @@ import java.util.List;
  * 권한과 인증 방식을 검사하는 필터입니다.
  *
  * @author 류태웅
- * @version 2024. 07. 27.
+ * @version 2024. 08. 02.
  */
 
 @Slf4j
@@ -44,116 +45,98 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final MemberRepository memberRepository;
     private final RefreshTokenService refreshTokenService;
 
-    /**
-     * 검증을 수행하는 메소드입니다.
-     * 여기서 jwtProvider의 validate를 수행합니다.
-     *
-     * @param request HttpServletRequest
-     * @param response HttpServletResponse
-     * @param filterChain FilterChain
-     * @throws ServletException ServletException
-     * @throws IOException IOException
-     */
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        log.info("도착한 요청: {}", request.getPathInfo());
+        log.info("도착한 요청: {}", request.getRequestURI());
         String token = parseBearerToken(request);
         log.info("도착한 토큰: {}", token);
-        if(token == null){ // Bearer 인증 방식이 아니거나 빈 값일 경우 진행하지 말고 다음 필터로 바로 넘김
+
+        if (token == null) {
             filterChain.doFilter(request, response);
             return;
         }
-        String kakaoId;
+
+        String kakaoId = null;
         try {
             kakaoId = jwtProvider.validate(token);
             log.info("검증된 카카오 ID: {}", kakaoId);
         } catch (ExpiredJwtException e) {
             log.error("엑세스 토큰이 만료됨", e);
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-            response.getWriter().write("{\"error\": \"Token expired\"}");
-            response.getWriter().flush();
+            setErrorResponse(response, "Token expired");
             return;
-        } catch (MalformedJwtException e){
+        } catch (MalformedJwtException e) {
             log.error("손상된 토큰", e);
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-            response.getWriter().write("{\"error\": \"Malformed Token\"}");
-            response.getWriter().flush();
+            setErrorResponse(response, "Malformed Token");
+            return;
+        } catch (JwtException e) {
+            log.error("토큰 검증 오류", e);
+            setErrorResponse(response, "Invalid Token");
             return;
         }
-        if (kakaoId == null) { // AccessToken 검증 실패 시
-            String refreshToken = parseRefreshToken(request);
-            log.info("도착한 리프레시 토큰: {}", refreshToken);
-            if (refreshToken != null && refreshTokenService.validateRefreshToken(refreshToken)) {
-                // RefreshToken이 유효한 경우 새로운 AccessToken 발급
-                kakaoId = jwtProvider.getSubjectFromRefreshToken(refreshToken);
-                token = jwtProvider.createAccessToken(kakaoId);
-                response.setHeader("Authorization", "Bearer " + token);
-                log.info("새로 발급된 엑세스 토큰: {}", token);
-            } else {
-                // RefreshToken도 유효하지 않으면 로그아웃 처리 및 프론트엔드로 메시지 전송
-                log.error("엑세스 토큰이 만료되었고 해당되는 리프레시 토큰이 존재하지 않습니다.");
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.setContentType("application/json");
-                response.getWriter().write("{\"error\": \"Invalid Refresh Token\"}");
-                response.getWriter().flush();
-                return;
-            }
+
+        if (kakaoId == null) {
+            handleTokenException(response, request);
+            return;
         }
+
+        processAuthentication(kakaoId, request);
+        filterChain.doFilter(request, response);
+    }
+
+    private void processAuthentication(String kakaoId, HttpServletRequest request) {
         Member member = memberRepository.findByKakaoId(Long.parseLong(kakaoId))
                 .orElseThrow(MemberNotFoundException::new);
-        Role role = member.getRole(); // ROLE_USER, ROLE_ADMIN
+        Role role = member.getRole();
 
-        // 예시 : ROLE_MASTER, ROLE_DEVELOPER
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority(role.toString()));
 
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-        AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(kakaoId, null, authorities); // pwd는 토큰에 추가X -> null
+        AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(kakaoId, null, authorities);
         authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
         securityContext.setAuthentication(authenticationToken);
         SecurityContextHolder.setContext(securityContext);
-
-        filterChain.doFilter(request, response);
     }
 
-    /**
-     * 헤더를 검증하는 메소드입니다.
-     * @param request HttpServletRequest
-     * @return authorization String
-     */
+    private void handleTokenException(HttpServletResponse response, HttpServletRequest request) throws IOException {
+        String refreshToken = parseRefreshToken(request);
+        log.info("도착한 리프레시 토큰: {}", refreshToken);
+
+        if (refreshToken != null && refreshTokenService.validateRefreshToken(refreshToken)) {
+            String kakaoId = jwtProvider.getSubjectFromRefreshToken(refreshToken);
+            String newToken = jwtProvider.createAccessToken(kakaoId);
+            response.setHeader("Authorization", "Bearer " + newToken);
+            log.info("새로 발급된 엑세스 토큰: {}", newToken);
+            processAuthentication(kakaoId, request);
+        } else {
+            log.error("엑세스 토큰이 만료되었고 해당되는 리프레시 토큰이 존재하지 않습니다.");
+            setErrorResponse(response, "Invalid Refresh Token");
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"" + message + "\"}");
+        response.getWriter().flush();
+    }
 
     private String parseBearerToken(HttpServletRequest request) {
-        String authorization = request.getHeader("Authorization"); // 응답의 헤더에서 뽑아옴
+        String authorization = request.getHeader("Authorization");
 
-        boolean hasAuthorization = StringUtils.hasText(authorization);
-        if(!hasAuthorization) return null; // null이거나 문자가 아닌 경우 null
-
-        boolean isBearer = authorization.startsWith("Bearer ");
-        if(!isBearer) return null; // 아닐 경우 Bearer 인증 방신이 아님 -> null
-
-        String token = authorization.substring(7);
-        if ("undefined".equalsIgnoreCase(token)) {
-            return null;
+        if (StringUtils.hasText(authorization) && authorization.startsWith("Bearer ")) {
+            String token = authorization.substring(7);
+            if (!"undefined".equalsIgnoreCase(token)) {
+                return token;
+            }
         }
 
-        return token;
+        return null;
     }
 
-    /**
-     * 헤더에서 RefreshToken을 검증하는 메소드입니다.
-     * @param request HttpServletRequest
-     * @return refreshToken String
-     */
     private String parseRefreshToken(HttpServletRequest request) {
         String refreshToken = request.getHeader("RefreshToken");
-
-        boolean hasRefreshToken = StringUtils.hasText(refreshToken);
-        if (!hasRefreshToken) return null;
-
-        return refreshToken;
+        return StringUtils.hasText(refreshToken) ? refreshToken : null;
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2FailureHandler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * 검증 실패 시 예외 처리 링크로 이동하는 핸들러입니다.
@@ -31,7 +32,7 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
             errorMessage="알 수 없는 이유로 로그인이 안되고 있습니다.";
         }
 
-        errorMessage= URLEncoder.encode(errorMessage,"UTF-8");//한글 인코딩 깨지는 문제 방지
+        errorMessage= URLEncoder.encode(errorMessage, StandardCharsets.UTF_8);//한글 인코딩 깨지는 문제 방지
         response.sendRedirect("http://localhost:8080/auth/oauth-response/error="+errorMessage);
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2FailureHandler.java
@@ -25,7 +25,7 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException e) throws IOException, ServletException {
         String errorMessage;
-        if (e instanceof UsernameNotFoundException){
+        if(e instanceof UsernameNotFoundException){
             errorMessage="존재하지 않는 아이디 입니다.";
         }
         else{

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2FailureHandler.java
@@ -1,0 +1,37 @@
+package com.dnd.jjakkak.domain.member.jwt.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+
+/**
+ * 검증 실패 시 예외 처리 링크로 이동하는 핸들러입니다.
+ *
+ * @author 류태웅
+ * @version 2024. 08. 02.
+ */
+
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException e) throws IOException, ServletException {
+        String errorMessage;
+        if (e instanceof UsernameNotFoundException){
+            errorMessage="존재하지 않는 아이디 입니다.";
+        }
+        else{
+            errorMessage="알 수 없는 이유로 로그인이 안되고 있습니다.";
+        }
+
+        errorMessage= URLEncoder.encode(errorMessage,"UTF-8");//한글 인코딩 깨지는 문제 방지
+        response.sendRedirect("http://localhost:8080/auth/oauth-response/error="+errorMessage);
+    }
+}

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2LogoutHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2LogoutHandler.java
@@ -16,25 +16,13 @@ import java.time.LocalDateTime;
 /**
  * 로그아웃 시 토큰에 빈 값을 넣어 전송 하는 방식으로 토큰을 삭제하는 핸들러입니다.
  *
- * @author 류태웅
- * @version 2024. 08. 02.
  */
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2LogoutHandler implements LogoutHandler {
     private final RefreshTokenService refreshTokenService;
     private final BlacklistService blacklistService;
-
-    /**
-     * 로그아웃 시 프론트 측에서 보내는 refresh_token과 일치한 지 확인 후
-     * 프론트엔드에게 빈 값의 쿠키를 보냄으로써 쿠키 삭제 (프론트에서도 쿠키 삭제 필요)
-     *
-     * @param request        HttpServletRequest
-     * @param response       HttpServletResponse
-     * @param authentication Authentication
-     */
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
@@ -62,20 +50,12 @@ public class OAuth2LogoutHandler implements LogoutHandler {
                     blacklistService.blacklistToken(refreshToken, expirationDate);
                     log.info("logout 성공");
 
-                    // 쿠키 삭제
-                    Cookie accessTokenCookie = new Cookie("access_token", null);
-                    accessTokenCookie.setPath("/");
-                    accessTokenCookie.setHttpOnly(true);
-                    accessTokenCookie.setSecure(true);
-                    accessTokenCookie.setMaxAge(0);
-
                     Cookie refreshTokenCookie = new Cookie("refresh_token", null);
                     refreshTokenCookie.setPath("/");
                     refreshTokenCookie.setHttpOnly(true);
                     refreshTokenCookie.setSecure(true);
                     refreshTokenCookie.setMaxAge(0);
 
-                    response.addCookie(accessTokenCookie);
                     response.addCookie(refreshTokenCookie);
 
                     response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2LogoutHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2LogoutHandler.java
@@ -15,7 +15,8 @@ import java.time.LocalDateTime;
 
 /**
  * 로그아웃 시 토큰에 빈 값을 넣어 전송 하는 방식으로 토큰을 삭제하는 핸들러입니다.
- *
+ * @author 류태웅
+ * @version 2024. 08. 03.
  */
 @Slf4j
 @Component
@@ -49,15 +50,6 @@ public class OAuth2LogoutHandler implements LogoutHandler {
                     LocalDateTime expirationDate = LocalDateTime.now().plusWeeks(1);
                     blacklistService.blacklistToken(refreshToken, expirationDate);
                     log.info("logout 성공");
-
-                    Cookie refreshTokenCookie = new Cookie("refresh_token", null);
-                    refreshTokenCookie.setPath("/");
-                    refreshTokenCookie.setHttpOnly(true);
-                    refreshTokenCookie.setSecure(true);
-                    refreshTokenCookie.setMaxAge(0);
-
-                    response.addCookie(refreshTokenCookie);
-
                     response.setStatus(HttpServletResponse.SC_OK);
                 } catch (Exception e) {
                     log.error("서버 에러", e);

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2LogoutHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2LogoutHandler.java
@@ -1,0 +1,95 @@
+package com.dnd.jjakkak.domain.member.jwt.handler;
+
+import com.dnd.jjakkak.domain.member.service.BlacklistService;
+import com.dnd.jjakkak.domain.member.service.RefreshTokenService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * 로그아웃 시 토큰에 빈 값을 넣어 전송 하는 방식으로 토큰을 삭제하는 핸들러입니다.
+ *
+ * @author 류태웅
+ * @version 2024. 08. 02.
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LogoutHandler implements LogoutHandler {
+    private final RefreshTokenService refreshTokenService;
+    private final BlacklistService blacklistService;
+
+    /**
+     * 로그아웃 시 프론트 측에서 보내는 refresh_token과 일치한 지 확인 후
+     * 프론트엔드에게 빈 값의 쿠키를 보냄으로써 쿠키 삭제 (프론트에서도 쿠키 삭제 필요)
+     *
+     * @param request        HttpServletRequest
+     * @param response       HttpServletResponse
+     * @param authentication Authentication
+     */
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        String refreshToken = null;
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh_token".equals(cookie.getName())) {
+                    refreshToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        log.info("logout 시작");
+
+        if (refreshToken != null) {
+            log.info("logout refreshToken: {}", refreshToken);
+
+            if (refreshTokenService.validateRefreshToken(refreshToken)) {
+                try {
+                    refreshTokenService.deleteRefreshToken(refreshToken);
+                    LocalDateTime expirationDate = LocalDateTime.now().plusWeeks(1);
+                    blacklistService.blacklistToken(refreshToken, expirationDate);
+                    log.info("logout 성공");
+
+                    // 쿠키 삭제
+                    Cookie accessTokenCookie = new Cookie("access_token", null);
+                    accessTokenCookie.setPath("/");
+                    accessTokenCookie.setHttpOnly(true);
+                    accessTokenCookie.setSecure(true);
+                    accessTokenCookie.setMaxAge(0);
+
+                    Cookie refreshTokenCookie = new Cookie("refresh_token", null);
+                    refreshTokenCookie.setPath("/");
+                    refreshTokenCookie.setHttpOnly(true);
+                    refreshTokenCookie.setSecure(true);
+                    refreshTokenCookie.setMaxAge(0);
+
+                    response.addCookie(accessTokenCookie);
+                    response.addCookie(refreshTokenCookie);
+
+                    response.setStatus(HttpServletResponse.SC_OK);
+                } catch (Exception e) {
+                    log.error("서버 에러", e);
+                    response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                }
+            } else {
+                log.error("Refresh Token 인증 오류");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            }
+        } else {
+            log.error("헤더 인증 오류");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2SuccessHandler.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * 검증 성공 시 토큰이 저장된 링크로 이동하는 핸들러입니다.
  *
  * @author 류태웅
- * @version 2024. 07. 27.
+ * @version 2024. 08. 02.
  */
 
 @Slf4j
@@ -68,6 +68,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.addCookie(refreshTokenCookie);
 
         // 로그인 성공 시 리다이렉트되는 URL은 추후 수정 필요
-        response.sendRedirect("http://localhost:8080/auth/oauth-response/");
+        response.sendRedirect("http://localhost:3000/");
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/handler/OAuth2SuccessHandler.java
@@ -17,11 +17,9 @@ import java.io.IOException;
 
 /**
  * 검증 성공 시 토큰이 저장된 링크로 이동하는 핸들러입니다.
- *
  * @author 류태웅
  * @version 2024. 08. 02.
  */
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -30,44 +28,33 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
 
-    /**
-     * 해당 메소드로 성공 시 링크로 이동합니다.
-     * 여기서 jwtProvider의 create를 수행합니다.
-     *
-     * @param request        HttpServletRequest
-     * @param response       HttpServletResponse
-     * @param authentication Authentication
-     * @throws IOException      IOException
-     * @throws ServletException ServletException
-     */
-
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         Member oauth2User = (Member) authentication.getPrincipal();
         String kakaoId = Long.toString(oauth2User.getKakaoId());
 
         // Access Token 생성
-        String token = jwtProvider.createAccessToken(kakaoId);
+        String accessToken = jwtProvider.createAccessToken(kakaoId);
 
         // Refresh Token 생성 및 저장
         String refreshToken = jwtProvider.createRefreshToken(kakaoId);
         refreshTokenService.createRefreshToken(oauth2User.getMemberId(), refreshToken);
 
-        Cookie accessTokenCookie = new Cookie("access_token", token);
-        accessTokenCookie.setSecure(true);
-        accessTokenCookie.setHttpOnly(true);
-        accessTokenCookie.setMaxAge(60*30); // 만료 시간 : 30분
-        accessTokenCookie.setPath("/"); // 모든 경로에서 접근 가능하도록 설정 (초 단위)
-        response.addCookie(accessTokenCookie);
+        log.info("access token: " + accessToken);
+        log.info("refresh token: " + refreshToken);
 
+        // Refresh Token 쿠키 설정
         Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
         refreshTokenCookie.setSecure(true);
         refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setMaxAge(60*60*24*7); // 만료 시간 : 1wn
-        refreshTokenCookie.setPath("/"); // 모든 경로에서 접근 가능하도록 설정 (초 단위)
-        response.addCookie(refreshTokenCookie);
+        refreshTokenCookie.setPath("/"); // 모든 경로에서 접근 가능하도록 설정
+        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7); // 1주일
 
-        // 로그인 성공 시 리다이렉트되는 URL은 추후 수정 필요
+        // 쿠키 추가
+        response.addCookie(refreshTokenCookie);
+        // Access Token을 헤더에 추가
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        // 리다이렉트할 URL 설정 (프론트엔드 페이지로 리다이렉트)
         response.sendRedirect("http://localhost:3000/");
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/member/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/dnd/jjakkak/domain/member/jwt/provider/JwtProvider.java
@@ -16,7 +16,7 @@ import java.util.Date;
  * JWT를 만들고 검증하는 Provider입니다.
  *
  * @author 류태웅
- * @version 2024. 07. 27.
+ * @version 2024. 08. 02.
  */
 
 @Slf4j
@@ -75,30 +75,14 @@ public class JwtProvider {
      * @return subject
      */
 
-    public String validate(String jwt) {
-        String subject;
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(jwt)
-                    .getBody();
-            subject = claims.getSubject();
-            log.info("subject, {}", subject);
-        } catch (ExpiredJwtException e) {
-            log.error("JWT 만료", e);
-            return null;
-        } catch (MalformedJwtException e) {
-            log.error("잘못된 토큰", e);
-            return null;
-        }
-        catch (Exception e) {
-            log.error("JWT 검증 실패", e);
-            return null;
-        }
-        return subject;
+    public String validate(String jwt) throws ExpiredJwtException, MalformedJwtException, JwtException {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(jwt)
+                .getBody();
+        return claims.getSubject();
     }
-
     /**
      * RefreshToken에서 subject를 추출하는 메소드
      *

--- a/src/main/java/com/dnd/jjakkak/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/jjakkak/global/config/security/SecurityConfig.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
  * Spring Security Configuration Class.
  *
  * @author 류태웅
- * @version 2024. 08. 02.
+ * @version 2024. 08. 03.
  */
 
 @Configurable
@@ -81,6 +81,7 @@ public class SecurityConfig {
                 .logout(logout -> logout
                         .addLogoutHandler(oAuth2LogoutHandler)
                         .logoutUrl("/api/v1/logout")
+                        .deleteCookies("refresh_token")
                         .logoutSuccessHandler((request, response, authentication) -> response.setStatus(HttpServletResponse.SC_OK))
                 )
                 .exceptionHandling(exceptionHandling -> exceptionHandling // 실패 시 해당 메시지 반환

--- a/src/main/java/com/dnd/jjakkak/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/jjakkak/global/config/security/SecurityConfig.java
@@ -104,7 +104,8 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(Arrays.asList("http://localhost:3000")); // 허용할 도메인 명시
         config.addAllowedMethod("*");
-        config.addAllowedHeader("*");
+        config.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Access-Control-Allow-Headers", "Access-Control-Expose-Headers"));
+        config.addExposedHeader("Authorization"); //프론트에서 해당 헤더를 읽을 수 있게
         config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/dnd/jjakkak/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/jjakkak/global/config/security/SecurityConfig.java
@@ -1,7 +1,10 @@
 package com.dnd.jjakkak.global.config.security;
 
 import com.dnd.jjakkak.domain.member.jwt.filter.JwtAuthenticationFilter;
+import com.dnd.jjakkak.domain.member.jwt.handler.OAuth2FailureHandler;
+import com.dnd.jjakkak.domain.member.jwt.handler.OAuth2LogoutHandler;
 import com.dnd.jjakkak.domain.member.jwt.handler.OAuth2SuccessHandler;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.context.annotation.Bean;
@@ -18,11 +21,13 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+
 /**
  * Spring Security Configuration Class.
  *
  * @author 류태웅
- * @version 2024. 07. 27.
+ * @version 2024. 08. 02.
  */
 
 @Configurable
@@ -34,6 +39,8 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final DefaultOAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final OAuth2LogoutHandler oAuth2LogoutHandler;
 
     /**
      * Security Bean 등록.
@@ -69,6 +76,12 @@ public class SecurityConfig {
                         .redirectionEndpoint(endpoint -> endpoint.baseUri("/oauth2/callback/*"))
                         .userInfoEndpoint(endpoint -> endpoint.userService(oAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
+                )
+                .logout(logout -> logout
+                        .addLogoutHandler(oAuth2LogoutHandler)
+                        .logoutUrl("/api/v1/logout")
+                        .logoutSuccessHandler((request, response, authentication) -> response.setStatus(HttpServletResponse.SC_OK))
                 )
                 .exceptionHandling(exceptionHandling -> exceptionHandling // 실패 시 해당 메시지 반환
                         .authenticationEntryPoint(new FailedAuthenticationEntryPoint())
@@ -81,7 +94,7 @@ public class SecurityConfig {
     /**
      * CORS 설정 용 메소드 추가
      *
-     * <li>추후 수정 필요</li>
+     * <li>credentials를 허용하기 위해 특정 도메인 추가</li>
      *
      * @return CorsConfigurationSource
      */
@@ -89,9 +102,10 @@ public class SecurityConfig {
     @Bean
     protected CorsConfigurationSource corsConfigurationSource() { // 추후 CORS 수정 필요
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("*");
+        config.setAllowedOrigins(Arrays.asList("http://localhost:3000")); // 허용할 도메인 명시
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
@@ -109,6 +123,4 @@ public class SecurityConfig {
         return web -> web.ignoring()
                 .requestMatchers("/favicon");
     }
-
-
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#40 

## 📝 작업 내용

* SuccessHandler 로직 수정 및 Token 전송 방식을 쿠키로 변경
* 로그인 실패 시 사용할 FailureHandler 추가
* AuthController의 /logout 삭제 및 LogoutHandler 추가
* 프론트엔드와의 통신을 위해 CORS에 특정 도메인 허용 및 setAllowCredentials(true) 설정
* AuthController에 현재 로그인 상태를 프론트엔드에게 보내서 확인해 줄 API 구현
