### PR TITLE
Refactor/#77 모임 리팩토링

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/controller/MeetingController.java
@@ -5,6 +5,7 @@ import com.dnd.jjakkak.domain.meeting.dto.response.MeetingCreateResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingInfoResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingParticipantResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingTimeResponseDto;
+import com.dnd.jjakkak.domain.meeting.enums.MeetingSort;
 import com.dnd.jjakkak.domain.meeting.service.MeetingService;
 import com.dnd.jjakkak.domain.member.dto.response.MemberResponseDto;
 import jakarta.validation.Valid;
@@ -57,14 +58,18 @@ public class MeetingController {
     }
 
     /**
-     * 모임의 최적 시간을 조회하는 메서드입니다.
+     * 모임의 시간을 조회하는 메서드입니다.
      *
      * @param uuid 조회할 모임 UUID
-     * @return 200 (OK), body: 최적 시간 응답 DTO
+     * @param sort 정렬 기준 (COUNT: 인원 수, LATEST: 최신순)
+     * @return 200 (OK), body: 정렬된 시간 응답 DTO 리스트
      */
-    @GetMapping("/{meetingUuid}/best-times")
-    public ResponseEntity<List<MeetingTimeResponseDto>> getBestTime(@PathVariable("meetingUuid") String uuid) {
-        return ResponseEntity.ok(meetingService.getBestTime(uuid));
+    @GetMapping("/{meetingUuid}/times")
+    public ResponseEntity<List<MeetingTimeResponseDto>> getMeetingTimes(
+            @PathVariable("meetingUuid") String uuid,
+            @RequestParam(value = "sort", defaultValue = "COUNT") MeetingSort sort) {
+
+        return ResponseEntity.ok(meetingService.getMeetingTimes(uuid, sort));
     }
 
     /**

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingParticipantResponseDto.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingParticipantResponseDto.java
@@ -34,10 +34,13 @@ public class MeetingParticipantResponseDto {
     public static class ParticipantInfo {
         private final String nickname;
         private final boolean isVoted;
+        private final boolean isLeader;
 
-        public ParticipantInfo(String nickname, boolean isVoted) {
+
+        public ParticipantInfo(String nickname, boolean isVoted, boolean isLeader) {
             this.nickname = nickname;
             this.isVoted = isVoted;
+            this.isLeader = isLeader;
         }
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingParticipantResponseDto.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingParticipantResponseDto.java
@@ -16,13 +16,13 @@ import java.util.List;
 public class MeetingParticipantResponseDto {
 
     private final Integer numberOfPeople;
-    private final boolean isAnonymous;
+    private final boolean anonymousStatus;
     private final List<ParticipantInfo> participantInfoList;
 
     @Builder
-    public MeetingParticipantResponseDto(Integer numberOfPeople, boolean isAnonymous) {
+    public MeetingParticipantResponseDto(Integer numberOfPeople, boolean anonymousStatus) {
         this.numberOfPeople = numberOfPeople;
-        this.isAnonymous = isAnonymous;
+        this.anonymousStatus = anonymousStatus;
         this.participantInfoList = new ArrayList<>();
     }
 
@@ -32,15 +32,15 @@ public class MeetingParticipantResponseDto {
 
     @Getter
     public static class ParticipantInfo {
+
         private final String nickname;
-        private final boolean isVoted;
-        private final boolean isLeader;
+        private final boolean votedStatus;
+        private final boolean leaderStatus;
 
-
-        public ParticipantInfo(String nickname, boolean isVoted, boolean isLeader) {
+        public ParticipantInfo(String nickname, boolean votedStatus, boolean leaderStatus) {
             this.nickname = nickname;
-            this.isVoted = isVoted;
-            this.isLeader = isLeader;
+            this.votedStatus = votedStatus;
+            this.leaderStatus = leaderStatus;
         }
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/enums/MeetingSort.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/enums/MeetingSort.java
@@ -1,0 +1,13 @@
+package com.dnd.jjakkak.domain.meeting.enums;
+
+/**
+ * 모임 응답 정렬 방식 Enum 입니다.
+ *
+ * @author 정승조
+ * @version 2024. 08. 21.
+ */
+public enum MeetingSort {
+
+    COUNT,
+    LATEST
+}

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepository.java
@@ -3,8 +3,6 @@ package com.dnd.jjakkak.domain.meeting.repository;
 import com.dnd.jjakkak.domain.meeting.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 /**
  * 모임 JPA 레포지토리입니다.
  *
@@ -21,12 +19,4 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long>,
      * @return 모임이 존재하는지 여부
      */
     boolean existsByMeetingUuid(String uuid);
-
-    /**
-     * 모임 uuid로 모임을 조회합니다.
-     *
-     * @param uuid 모임 uuid
-     * @return 모임
-     */
-    Optional<Meeting> findByMeetingUuid(String uuid);
 }

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryCustom.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.dnd.jjakkak.domain.meeting.repository;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingInfoResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingParticipantResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingTimeResponseDto;
+import com.dnd.jjakkak.domain.meeting.enums.MeetingSort;
 import org.springframework.data.repository.NoRepositoryBean;
 
 import java.util.List;
@@ -41,12 +42,13 @@ public interface MeetingRepositoryCustom {
     MeetingInfoResponseDto getMeetingInfo(String uuid);
 
     /**
-     * 모임의 UUID로 최적의 시간을 조회합니다.
+     * 모임의 UUID로 시간을 조회합니다.
      *
      * @param uuid 모임 UUID
+     * @param sort 정렬 기준
      * @return 최적의 시간 응답 DTO 리스트
      */
-    List<MeetingTimeResponseDto> getBestTime(String uuid);
+    List<MeetingTimeResponseDto> getMeetingTimes(String uuid, MeetingSort sort);
 
     /**
      * 모임의 UUID로 참가자를 조회합니다.

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
@@ -9,6 +9,7 @@ import com.dnd.jjakkak.domain.meeting.dto.response.MeetingInfoResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingParticipantResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingTimeResponseDto;
 import com.dnd.jjakkak.domain.meeting.entity.Meeting;
+import com.dnd.jjakkak.domain.meeting.enums.MeetingSort;
 import com.dnd.jjakkak.domain.meeting.exception.MeetingNotFoundException;
 import com.dnd.jjakkak.domain.meeting.exception.MeetingUnauthorizedException;
 import com.dnd.jjakkak.domain.meeting.repository.MeetingRepository;
@@ -152,19 +153,20 @@ public class MeetingService {
     }
 
     /**
-     * 모임의 최적 시간을 조회하는 메서드입니다.
+     * 모임의 시간을 조회하는 메서드입니다.
      *
      * @param uuid 조회할 모임 UUID
-     * @return 최적 시간 응답 DTO (오름차순으로 정렬)
+     * @param sort 정렬 기준 (COUNT: 인원 수, LATEST: 최신순)
+     * @return 정렬된 시간 응답 DTO 리스트
      */
     @Transactional(readOnly = true)
-    public List<MeetingTimeResponseDto> getBestTime(String uuid) {
+    public List<MeetingTimeResponseDto> getMeetingTimes(String uuid, MeetingSort sort) {
 
         if (!meetingRepository.existsByMeetingUuid(uuid)) {
             throw new MeetingNotFoundException();
         }
 
-        return meetingRepository.getBestTime(uuid);
+        return meetingRepository.getMeetingTimes(uuid, sort);
     }
 
     /**

--- a/src/main/java/com/dnd/jjakkak/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/dnd/jjakkak/domain/schedule/entity/Schedule.java
@@ -36,7 +36,7 @@ public class Schedule {
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/dnd/jjakkak/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/dnd/jjakkak/domain/schedule/service/ScheduleService.java
@@ -54,7 +54,7 @@ public class ScheduleService {
         // 일정 생성
         Schedule schedule = Schedule.builder()
                 .meeting(meeting)
-                .scheduleNickname("익명")
+                .scheduleNickname("멤버")
                 .scheduleUuid(uuid)
                 .build();
 

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/MeetingDummy.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/MeetingDummy.java
@@ -81,7 +81,7 @@ public class MeetingDummy {
 
         MeetingParticipantResponseDto response = MeetingParticipantResponseDto.builder()
                 .numberOfPeople(2)
-                .isAnonymous(false)
+                .anonymousStatus(false)
                 .build();
 
         MeetingParticipantResponseDto.ParticipantInfo whale

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/MeetingDummy.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/MeetingDummy.java
@@ -85,10 +85,10 @@ public class MeetingDummy {
                 .build();
 
         MeetingParticipantResponseDto.ParticipantInfo whale
-                = new MeetingParticipantResponseDto.ParticipantInfo("고래", true);
+                = new MeetingParticipantResponseDto.ParticipantInfo("고래", true, true);
 
         MeetingParticipantResponseDto.ParticipantInfo shark
-                = new MeetingParticipantResponseDto.ParticipantInfo("상어", true);
+                = new MeetingParticipantResponseDto.ParticipantInfo("상어", true, false);
 
         response.addParticipantInfoList(List.of(whale, shark));
 

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/controller/MeetingControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -148,10 +149,11 @@ class MeetingControllerTest extends AbstractRestDocsTest {
     void getBestTime_success() throws Exception {
 
         String meetingUuid = "123ABC";
-        when(meetingService.getBestTime(anyString()))
+        when(meetingService.getMeetingTimes(anyString(), any()))
                 .thenReturn(MeetingDummy.createBestTimeResponse());
 
-        mockMvc.perform(get("/api/v1/meetings/{meetingUuid}/best-times", meetingUuid)
+        mockMvc.perform(get("/api/v1/meetings/{meetingUuid}/times", meetingUuid)
+                        .param("sort", "COUNT")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpectAll(
@@ -193,7 +195,8 @@ class MeetingControllerTest extends AbstractRestDocsTest {
                         jsonPath("$.participantInfoList.[0].voted").value(true),
                         jsonPath("$.participantInfoList.[1].nickname").value("상어"),
                         jsonPath("$.participantInfoList.[1].voted").value(true),
-                        jsonPath("$.anonymous").value(false))
+                        jsonPath("$.anonymous").value(false),
+                        jsonPath("$.leader").value(false))
                 .andDo(restDocs.document(
                         pathParameters(
                                 parameterWithName("meetingUuid").description("모임 UUID")
@@ -202,7 +205,8 @@ class MeetingControllerTest extends AbstractRestDocsTest {
                                 fieldWithPath("numberOfPeople").description("참석자 수"),
                                 fieldWithPath("participantInfoList.[].nickname").description("참석자 닉네임"),
                                 fieldWithPath("participantInfoList.[].voted").description("투표 여부"),
-                                fieldWithPath("anonymous").description("익명 여부")
+                                fieldWithPath("anonymous").description("익명 여부"),
+                                fieldWithPath("leader").description("리더 여부")
                         ))
                 );
     }

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/controller/MeetingControllerTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/controller/MeetingControllerTest.java
@@ -191,22 +191,23 @@ class MeetingControllerTest extends AbstractRestDocsTest {
                 .andExpectAll(
                         status().isOk(),
                         jsonPath("$.numberOfPeople").value(2),
+                        jsonPath("$.anonymousStatus").value(false),
                         jsonPath("$.participantInfoList.[0].nickname").value("고래"),
-                        jsonPath("$.participantInfoList.[0].voted").value(true),
+                        jsonPath("$.participantInfoList.[0].votedStatus").value(true),
+                        jsonPath("$.participantInfoList.[0].leaderStatus").value(true),
                         jsonPath("$.participantInfoList.[1].nickname").value("상어"),
-                        jsonPath("$.participantInfoList.[1].voted").value(true),
-                        jsonPath("$.anonymous").value(false),
-                        jsonPath("$.leader").value(false))
+                        jsonPath("$.participantInfoList.[1].votedStatus").value(true),
+                        jsonPath("$.participantInfoList.[1].leaderStatus").value(false))
                 .andDo(restDocs.document(
                         pathParameters(
                                 parameterWithName("meetingUuid").description("모임 UUID")
                         ),
                         responseFields(
                                 fieldWithPath("numberOfPeople").description("참석자 수"),
+                                fieldWithPath("anonymousStatus").description("익명 여부"),
                                 fieldWithPath("participantInfoList.[].nickname").description("참석자 닉네임"),
-                                fieldWithPath("participantInfoList.[].voted").description("투표 여부"),
-                                fieldWithPath("anonymous").description("익명 여부"),
-                                fieldWithPath("leader").description("리더 여부")
+                                fieldWithPath("participantInfoList.[].votedStatus").description("투표 여부"),
+                                fieldWithPath("participantInfoList.[].leaderStatus").description("리더 여부")
                         ))
                 );
     }

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryTest.java
@@ -343,15 +343,15 @@ class MeetingRepositoryTest {
         MeetingParticipantResponseDto.ParticipantInfo leaderInfo = participantInfoList.get(0);
         assertAll(
                 () -> assertEquals("승조", leaderInfo.getNickname()),
-                () -> assertTrue(leaderInfo.isVoted()),
-                () -> assertTrue(leaderInfo.isLeader())
+                () -> assertTrue(leaderInfo.isVotedStatus()),
+                () -> assertTrue(leaderInfo.isLeaderStatus())
         );
 
         MeetingParticipantResponseDto.ParticipantInfo memberInfo = participantInfoList.get(1);
         assertAll(
                 () -> assertEquals("멤버2", memberInfo.getNickname()),
-                () -> assertFalse(memberInfo.isVoted()),
-                () -> assertFalse(memberInfo.isLeader())
+                () -> assertFalse(memberInfo.isVotedStatus()),
+                () -> assertFalse(memberInfo.isLeaderStatus())
         );
     }
 }

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryTest.java
@@ -1,0 +1,357 @@
+package com.dnd.jjakkak.domain.meeting.repository;
+
+import com.dnd.jjakkak.domain.category.entity.Category;
+import com.dnd.jjakkak.domain.dateofschedule.entity.DateOfSchedule;
+import com.dnd.jjakkak.domain.meeting.dto.response.MeetingInfoResponseDto;
+import com.dnd.jjakkak.domain.meeting.dto.response.MeetingParticipantResponseDto;
+import com.dnd.jjakkak.domain.meeting.dto.response.MeetingTimeResponseDto;
+import com.dnd.jjakkak.domain.meeting.entity.Meeting;
+import com.dnd.jjakkak.domain.meeting.enums.MeetingSort;
+import com.dnd.jjakkak.domain.meetingcategory.entity.MeetingCategory;
+import com.dnd.jjakkak.domain.member.entity.Member;
+import com.dnd.jjakkak.domain.schedule.entity.Schedule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 모임 레포지토리 테스트 클래스입니다.
+ *
+ * @author 정승조
+ * @version 2024. 08. 21.
+ */
+@DataJpaTest
+class MeetingRepositoryTest {
+
+    @Autowired
+    MeetingRepository meetingRepository;
+
+    @Autowired
+    TestEntityManager em;
+
+    Meeting testMeeting;
+
+    @BeforeEach
+    void setUp() {
+
+        Category category = Category.builder()
+                .categoryName("스터디")
+                .build();
+
+        em.persist(category);
+
+        Meeting meeting = Meeting.builder()
+                .meetingLeaderId(1L)
+                .meetingName("백엔드 개발")
+                .meetingUuid("123abc")
+                .numberOfPeople(5)
+                .meetingStartDate(LocalDate.of(2024, 8, 21))
+                .meetingEndDate(LocalDate.of(2024, 8, 23))
+                .voteEndDate(LocalDateTime.of(2024, 8, 20, 23, 59, 59))
+                .isAnonymous(false)
+                .build();
+
+        testMeeting = em.persist(meeting);
+
+
+        MeetingCategory.Pk pk = new MeetingCategory.Pk(testMeeting.getMeetingId(), category.getCategoryId());
+        MeetingCategory meetingCategory = MeetingCategory.builder()
+                .pk(pk)
+                .category(category)
+                .meeting(testMeeting)
+                .build();
+
+        em.persist(meetingCategory);
+
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("모임 uuid 존재 여부 확인")
+    void existsByMeetingUuid() {
+        // given
+        String uuid = "123abc";
+
+        // when
+        boolean exists = meetingRepository.existsByMeetingUuid(uuid);
+
+        // then
+        assertTrue(exists);
+    }
+
+    @Test
+    @DisplayName("모임 uuid 존재 여부 확인 - 존재하지 않는 경우")
+    void existsByMeetingUuid_notExists() {
+        // given
+        String uuid = "abc123";
+
+        // when
+        boolean exists = meetingRepository.existsByMeetingUuid(uuid);
+
+        // then
+        assertFalse(exists);
+    }
+
+    @Test
+    @DisplayName("모임 인원 체크 테스트")
+    void checkMeetingIsFull() {
+
+        // given
+        Schedule schedule1 = Schedule.builder()
+                .meeting(testMeeting)
+                .scheduleNickname("멤버1")
+                .scheduleUuid("123abc")
+                .build();
+
+        Schedule schedule2 = Schedule.builder()
+                .meeting(testMeeting)
+                .scheduleNickname("멤버2")
+                .scheduleUuid("456def")
+                .build();
+
+        em.persist(schedule1);
+        em.persist(schedule2);
+
+        // when
+        boolean isFull = meetingRepository.checkMeetingFull(testMeeting.getMeetingId());
+
+        // then
+        assertFalse(isFull);
+    }
+
+    @Test
+    @DisplayName("모임이 익명인지 확인")
+    void isAnonymous() {
+        // when
+        boolean isAnonymous = meetingRepository.isAnonymous(testMeeting.getMeetingId());
+
+        // then
+        assertFalse(isAnonymous);
+    }
+
+    @Test
+    @DisplayName("모임 정보 조회")
+    void getMeetingInfo() {
+
+        // given
+        String uuid = "123abc";
+
+        // when
+        MeetingInfoResponseDto meetingInfo = meetingRepository.getMeetingInfo(uuid);
+
+        // then
+        assertAll(
+                () -> assertEquals(testMeeting.getMeetingId(), meetingInfo.getMeetingId()),
+                () -> assertEquals(testMeeting.getMeetingName(), meetingInfo.getMeetingName()),
+                () -> assertEquals(testMeeting.getMeetingStartDate(), meetingInfo.getMeetingStartDate()),
+                () -> assertEquals(testMeeting.getMeetingEndDate(), meetingInfo.getMeetingEndDate())
+        );
+
+        List<String> categoryNames = meetingInfo.getCategoryNames();
+        assertEquals(1, categoryNames.size());
+        assertEquals("스터디", categoryNames.get(0));
+    }
+
+    @Test
+    @DisplayName("모임 시간 조회 - COUNT 기준 정렬")
+    void getMeetingTimes_defaultSort() {
+        // given
+
+        Schedule schedule1 = Schedule.builder()
+                .meeting(testMeeting)
+                .scheduleNickname("멤버1")
+                .scheduleUuid("123abc")
+                .build();
+
+        em.persist(schedule1);
+
+
+        DateOfSchedule dateOfSchedule1 = DateOfSchedule.builder()
+                .schedule(schedule1)
+                .dateOfScheduleRank(1)
+                .dateOfScheduleStart(LocalDateTime.of(2024, 8, 21, 10, 0))
+                .dateOfScheduleEnd(LocalDateTime.of(2024, 8, 21, 12, 0))
+                .build();
+
+        DateOfSchedule dateOfSchedule2 = DateOfSchedule.builder()
+                .schedule(schedule1)
+                .dateOfScheduleRank(2)
+                .dateOfScheduleStart(LocalDateTime.of(2024, 8, 22, 10, 0))
+                .dateOfScheduleEnd(LocalDateTime.of(2024, 8, 22, 12, 0))
+                .build();
+
+        em.persist(dateOfSchedule1);
+        em.persist(dateOfSchedule2);
+
+        Schedule schedule2 = Schedule.builder()
+                .meeting(testMeeting)
+                .scheduleNickname("멤버2")
+                .scheduleUuid("456def")
+                .build();
+
+        em.persist(schedule2);
+
+        DateOfSchedule dateOfSchedule3 = DateOfSchedule.builder()
+                .schedule(schedule2)
+                .dateOfScheduleRank(1)
+                .dateOfScheduleStart(LocalDateTime.of(2024, 8, 21, 10, 0))
+                .dateOfScheduleEnd(LocalDateTime.of(2024, 8, 21, 12, 0))
+                .build();
+
+        em.persist(dateOfSchedule3);
+
+        em.flush();
+
+        String uuid = "123abc";
+
+        // when
+        List<MeetingTimeResponseDto> meetingTimes = meetingRepository.getMeetingTimes(uuid, MeetingSort.COUNT);
+
+        // then
+        assertEquals(2, meetingTimes.size());
+
+        MeetingTimeResponseDto primary = meetingTimes.get(0);
+        assertAll(
+                () -> assertEquals(dateOfSchedule1.getDateOfScheduleStart(), primary.getStartTime()),
+                () -> assertEquals(dateOfSchedule1.getDateOfScheduleEnd(), primary.getEndTime())
+        );
+
+        MeetingTimeResponseDto secondary = meetingTimes.get(1);
+        assertAll(
+                () -> assertEquals(dateOfSchedule2.getDateOfScheduleStart(), secondary.getStartTime()),
+                () -> assertEquals(dateOfSchedule2.getDateOfScheduleEnd(), secondary.getEndTime())
+        );
+    }
+
+
+    @Test
+    @DisplayName("모임 시간 조회 - LATEST 기준 정렬")
+    void getMeetingTimes_latestSort() {
+        // given
+
+        Schedule schedule1 = Schedule.builder()
+                .meeting(testMeeting)
+                .scheduleNickname("멤버1")
+                .scheduleUuid("123abc")
+                .build();
+
+
+        DateOfSchedule dateOfSchedule1 = DateOfSchedule.builder()
+                .schedule(schedule1)
+                .dateOfScheduleRank(1)
+                .dateOfScheduleStart(LocalDateTime.of(2024, 8, 23, 10, 0))
+                .dateOfScheduleEnd(LocalDateTime.of(2024, 8, 23, 12, 0))
+                .build();
+
+        em.persist(schedule1);
+        em.persist(dateOfSchedule1);
+
+        Schedule schedule2 = Schedule.builder()
+                .meeting(testMeeting)
+                .scheduleNickname("멤버2")
+                .scheduleUuid("456def")
+                .build();
+
+        DateOfSchedule dateOfSchedule2 = DateOfSchedule.builder()
+                .schedule(schedule2)
+                .dateOfScheduleRank(2)
+                .dateOfScheduleStart(LocalDateTime.of(2024, 8, 21, 10, 0))
+                .dateOfScheduleEnd(LocalDateTime.of(2024, 8, 21, 12, 0))
+                .build();
+
+        em.persist(schedule2);
+        em.persist(dateOfSchedule2);
+
+        em.flush();
+
+        String uuid = "123abc";
+
+        // when
+        List<MeetingTimeResponseDto> meetingTimes = meetingRepository.getMeetingTimes(uuid, MeetingSort.LATEST);
+
+        // then
+        assertEquals(2, meetingTimes.size());
+
+        MeetingTimeResponseDto primary = meetingTimes.get(0);
+        assertAll(
+                () -> assertEquals(dateOfSchedule2.getDateOfScheduleStart(), primary.getStartTime()),
+                () -> assertEquals(dateOfSchedule2.getDateOfScheduleEnd(), primary.getEndTime())
+        );
+
+        MeetingTimeResponseDto secondary = meetingTimes.get(1);
+        assertAll(
+                () -> assertEquals(dateOfSchedule1.getDateOfScheduleStart(), secondary.getStartTime()),
+                () -> assertEquals(dateOfSchedule1.getDateOfScheduleEnd(), secondary.getEndTime())
+        );
+    }
+
+    @Test
+    @DisplayName("모임 참가자 조회")
+    void getParticipant() {
+
+        // given
+        Member leader = Member.builder()
+                .memberNickname("승조")
+                .build();
+
+        ReflectionTestUtils.setField(leader, "memberId", 1L);
+
+        em.merge(leader);
+
+        Schedule schedule1 = Schedule.builder()
+                .member(leader)
+                .scheduleNickname(leader.getMemberNickname())
+                .meeting(testMeeting)
+                .scheduleUuid("123abc")
+                .build();
+
+        schedule1.scheduleAssign();
+
+        Schedule schedule2 = Schedule.builder()
+                .meeting(testMeeting)
+                .scheduleNickname("멤버2")
+                .scheduleUuid("456def")
+                .build();
+
+        em.persist(schedule1);
+        em.persist(schedule2);
+
+        em.flush();
+        // em.clear();  // clear를 사용하면 엔티티가 detached 상태가 되므로 주의 필요
+
+        String uuid = "123abc";
+
+        // when
+        MeetingParticipantResponseDto participant = meetingRepository.getParticipant(uuid);
+
+        // then
+        assertEquals(5, participant.getNumberOfPeople());
+
+        List<MeetingParticipantResponseDto.ParticipantInfo> participantInfoList = participant.getParticipantInfoList();
+        assertEquals(2, participantInfoList.size());
+
+        MeetingParticipantResponseDto.ParticipantInfo leaderInfo = participantInfoList.get(0);
+        assertAll(
+                () -> assertEquals("승조", leaderInfo.getNickname()),
+                () -> assertTrue(leaderInfo.isVoted()),
+                () -> assertTrue(leaderInfo.isLeader())
+        );
+
+        MeetingParticipantResponseDto.ParticipantInfo memberInfo = participantInfoList.get(1);
+        assertAll(
+                () -> assertEquals("멤버2", memberInfo.getNickname()),
+                () -> assertFalse(memberInfo.isVoted()),
+                () -> assertFalse(memberInfo.isLeader())
+        );
+    }
+}

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/service/MeetingServiceTest.java
@@ -234,7 +234,7 @@ class MeetingServiceTest {
 
         assertAll(
                 () -> assertEquals(expected.getNumberOfPeople(), actual.getNumberOfPeople()),
-                () -> assertEquals(expected.isAnonymous(), actual.isAnonymous())
+                () -> assertEquals(expected.isAnonymousStatus(), actual.isAnonymousStatus())
         );
 
         verify(meetingRepository, times(1)).getParticipant(uuid);

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/service/MeetingServiceTest.java
@@ -8,6 +8,7 @@ import com.dnd.jjakkak.domain.meeting.dto.response.MeetingInfoResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingParticipantResponseDto;
 import com.dnd.jjakkak.domain.meeting.dto.response.MeetingTimeResponseDto;
 import com.dnd.jjakkak.domain.meeting.entity.Meeting;
+import com.dnd.jjakkak.domain.meeting.enums.MeetingSort;
 import com.dnd.jjakkak.domain.meeting.exception.MeetingNotFoundException;
 import com.dnd.jjakkak.domain.meeting.repository.MeetingRepository;
 import com.dnd.jjakkak.domain.meetingcategory.repository.MeetingCategoryRepository;
@@ -172,19 +173,19 @@ class MeetingServiceTest {
     }
 
     @Test
-    @DisplayName("모임 최적 시간 조회 - 성공")
+    @DisplayName("모임 시간 조회 - 성공")
     void testGetMeetingBestTime_Success() {
 
         String uuid = "1234abcd";
         List<MeetingTimeResponseDto> expected = MeetingDummy.createBestTimeResponse();
 
-        when(meetingRepository.getBestTime(anyString()))
+        when(meetingRepository.getMeetingTimes(anyString(), any()))
                 .thenReturn(expected);
 
         when(meetingRepository.existsByMeetingUuid(anyString()))
                 .thenReturn(true);
 
-        List<MeetingTimeResponseDto> actual = meetingService.getBestTime(uuid);
+        List<MeetingTimeResponseDto> actual = meetingService.getMeetingTimes(uuid, MeetingSort.COUNT);
 
         assertEquals(expected.size(), actual.size());
 
@@ -198,12 +199,12 @@ class MeetingServiceTest {
                 () -> assertEquals(expectedTime.getRank(), actualTime.getRank())
         );
 
-        verify(meetingRepository, times(1)).getBestTime(uuid);
+        verify(meetingRepository, times(1)).getMeetingTimes(uuid, MeetingSort.COUNT);
         verify(meetingRepository, times(1)).existsByMeetingUuid(uuid);
     }
 
     @Test
-    @DisplayName("모임 최적 시간 조회 - 실패 (존재하지 않는 모임)")
+    @DisplayName("모임 시간 조회 - 실패 (존재하지 않는 모임)")
     void testGetMeetingBestTime_Fail() {
 
         String uuid = "1234abcd";
@@ -213,7 +214,7 @@ class MeetingServiceTest {
 
         // expected
         assertThrows(MeetingNotFoundException.class,
-                () -> meetingService.getBestTime(uuid));
+                () -> meetingService.getMeetingTimes(uuid, MeetingSort.COUNT));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#77 

## 📝 작업 내용

> 회의 내용을 바탕으로 모임 리팩토링을 진행하였습니다.

1. 일정의 기본 닉네임 - '익명' &rarr; '멤버'
2. 모임의 유저 정보를 조회할 때 리더인지 파악하는 boolean 값 추가 (`isLeader`)
3. 모임의 일정을 조회할 때 `@RequestParam` 을 통해 정렬 기준 설정을 설정하고 Querydsl 의 `OrderSpecifier` 활용
  - 많은 사람이 선택한 순 : COUNT (default)
  - 빠른 시간 순 : LATEST

## 💬 리뷰 요구사항

Response DTO 필드명이 `isLeader` 처럼 is로 시작하는 경우, `leader` 로 응답을 하게 됩니다.
이러한 문제는 json 을 역/직렬화 하는 과정에서 jackson 라이브러리를 사용하여 Getter를 통해 값을 binding 해주기 때문에 is prefix는 사라지게 된다고 합니다.

이러한 문제점을 해결하기 위해서 `@JsonProperty` 를 사용하면 된다고는 하는데, 이런식으로 변경을 해야할까요? 

> 참고자료 : [Boolean에 is 붙이지 마세요!](https://medium.com/@baejae/boolean%EC%97%90-is-%EB%B6%99%EC%9D%B4%EC%A7%80-%EB%A7%88%EC%84%B8%EC%9A%94-7b717246d942)