### PR TITLE
[Fix] 일정 할당 동시성 제어 

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryCustom.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryCustom.java
@@ -21,10 +21,10 @@ public interface MeetingRepositoryCustom {
     /**
      * 모임의 인원이 꽉 찼는지 확인합니다.
      *
-     * @param meetingId 모임 ID
+     * @param meetingUuid 모임 UUID
      * @return 모임의 인원이 꽉 찼는지 여부
      */
-    boolean checkMeetingFull(Long meetingId);
+    boolean checkMeetingFull(String meetingUuid);
 
     /**
      * 모임이 익명인지 확인합니다.

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
@@ -39,17 +39,17 @@ public class MeetingRepositoryImpl extends QuerydslRepositorySupport implements 
      * {@inheritDoc}
      */
     @Override
-    public boolean checkMeetingFull(Long meetingId) {
+    public boolean checkMeetingFull(String meetingUuid) {
         QMeeting meeting = QMeeting.meeting;
         QSchedule schedule = QSchedule.schedule;
 
         Integer maxPeople = from(meeting)
-                .where(meeting.meetingId.eq(meetingId))
+                .where(meeting.meetingUuid.eq(meetingUuid))
                 .select(meeting.numberOfPeople)
                 .fetchOne();
 
         Long currentPeople = from(schedule)
-                .where(schedule.meeting.meetingId.eq(meetingId)
+                .where(schedule.meeting.meetingUuid.eq(meetingUuid)
                         .and(schedule.isAssigned.isTrue()))
                 .select(schedule.scheduleId.count())
                 .fetchOne();

--- a/src/main/java/com/dnd/jjakkak/domain/redis/RedisRepository.java
+++ b/src/main/java/com/dnd/jjakkak/domain/redis/RedisRepository.java
@@ -1,0 +1,37 @@
+package com.dnd.jjakkak.domain.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+/**
+ * Redis 접근하는 Repository 클래스입니다.
+ *
+ * @author 정승조
+ * @version 2024. 10. 11.
+ */
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String findByKey(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void save(String key, String value, Duration expiration) {
+        redisTemplate.opsForValue().set(key, value, expiration);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public Boolean lock(String key) {
+        return redisTemplate.opsForValue()
+                .setIfAbsent(key, "lock", Duration.ofSeconds(5));
+    }
+}

--- a/src/main/java/com/dnd/jjakkak/domain/refreshtoken/service/RefreshTokenService.java
+++ b/src/main/java/com/dnd/jjakkak/domain/refreshtoken/service/RefreshTokenService.java
@@ -1,8 +1,8 @@
 package com.dnd.jjakkak.domain.refreshtoken.service;
 
+import com.dnd.jjakkak.domain.redis.RedisRepository;
 import com.dnd.jjakkak.global.config.proprties.TokenProperties;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -17,8 +17,8 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
-    private final RedisTemplate<String, String> redisTemplate;
     private final TokenProperties tokenProperties;
+    private final RedisRepository redisRepository;
 
     /**
      * Kakao ID로 RT를 조회하는 메서드.
@@ -27,7 +27,7 @@ public class RefreshTokenService {
      * @return 저장되어있는 RT 값
      */
     public String findByKakaoId(String kakaoId) {
-        return redisTemplate.opsForValue().get(kakaoId);
+        return redisRepository.findByKey(kakaoId);
     }
 
 
@@ -38,7 +38,8 @@ public class RefreshTokenService {
      * @param refreshToken 저장할 RT 값
      */
     public void saveRefreshToken(String kakaoId, String refreshToken) {
-        redisTemplate.opsForValue().set(kakaoId, refreshToken, Duration.ofDays(tokenProperties.getRefreshTokenExpirationDay()));
+        Duration expiration = Duration.ofDays(tokenProperties.getRefreshTokenExpirationDay());
+        redisRepository.save(kakaoId, refreshToken, expiration);
     }
 
 
@@ -48,8 +49,6 @@ public class RefreshTokenService {
      * @param kakaoId 회원의 카카오 ID
      */
     public void deleteRefreshToken(String kakaoId) {
-        redisTemplate.delete(kakaoId);
+        redisRepository.delete(kakaoId);
     }
-
-
 }

--- a/src/main/java/com/dnd/jjakkak/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/dnd/jjakkak/domain/schedule/controller/ScheduleController.java
@@ -4,6 +4,7 @@ import com.dnd.jjakkak.domain.schedule.dto.request.ScheduleAssignRequestDto;
 import com.dnd.jjakkak.domain.schedule.dto.request.ScheduleUpdateRequestDto;
 import com.dnd.jjakkak.domain.schedule.dto.response.ScheduleAssignResponseDto;
 import com.dnd.jjakkak.domain.schedule.dto.response.ScheduleResponseDto;
+import com.dnd.jjakkak.domain.schedule.facade.ScheduleFacade;
 import com.dnd.jjakkak.domain.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
+    private final ScheduleFacade scheduleFacade;
 
     /**
      * 회원의 일정을 모임에 할당하는 메서드입니다.
@@ -37,7 +39,7 @@ public class ScheduleController {
                                                        @AuthenticationPrincipal Long memberId,
                                                        @Valid @RequestBody ScheduleAssignRequestDto requestDto) {
 
-        scheduleService.assignScheduleToMember(memberId, meetingUuid, requestDto);
+        scheduleFacade.assignScheduleToMember(memberId, meetingUuid, requestDto);
         return ResponseEntity.ok().build();
     }
 
@@ -52,7 +54,7 @@ public class ScheduleController {
     public ResponseEntity<ScheduleAssignResponseDto> assignScheduleToGuest(@PathVariable("meetingUuid") String meetingUuid,
                                                                            @Valid @RequestBody ScheduleAssignRequestDto requestDto) {
 
-        ScheduleAssignResponseDto responseDto = scheduleService.assignScheduleToGuest(meetingUuid, requestDto);
+        ScheduleAssignResponseDto responseDto = scheduleFacade.assignScheduleToGuest(meetingUuid, requestDto);
         return ResponseEntity.ok(responseDto);
     }
 
@@ -95,7 +97,7 @@ public class ScheduleController {
      */
     @GetMapping("/check")
     public ResponseEntity<Boolean> getMemberScheduleWrite(@PathVariable("meetingUuid") String meetingUuid,
-                                                          @AuthenticationPrincipal Long memberId){
+                                                          @AuthenticationPrincipal Long memberId) {
         return ResponseEntity.ok(scheduleService.getMemberScheduleWrite(meetingUuid, memberId));
     }
 

--- a/src/main/java/com/dnd/jjakkak/domain/schedule/facade/ScheduleFacade.java
+++ b/src/main/java/com/dnd/jjakkak/domain/schedule/facade/ScheduleFacade.java
@@ -1,0 +1,58 @@
+package com.dnd.jjakkak.domain.schedule.facade;
+
+import com.dnd.jjakkak.domain.redis.RedisRepository;
+import com.dnd.jjakkak.domain.schedule.dto.request.ScheduleAssignRequestDto;
+import com.dnd.jjakkak.domain.schedule.dto.response.ScheduleAssignResponseDto;
+import com.dnd.jjakkak.domain.schedule.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 일정 Facade 클래스입니다.
+ *
+ * @author 정승조
+ * @version 2024. 10. 11.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleFacade {
+
+    private final RedisRepository redisRepository;
+    private final ScheduleService scheduleService;
+
+    public void assignScheduleToMember(Long memberId, String meetingUuid, ScheduleAssignRequestDto requestDto) {
+        String key = "meeting-" + meetingUuid;
+        while (!redisRepository.lock(key)) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        try {
+            scheduleService.assignScheduleToMember(memberId, meetingUuid, requestDto);
+        } finally {
+            redisRepository.delete(key);
+        }
+    }
+
+    public ScheduleAssignResponseDto assignScheduleToGuest(String meetingUuid, ScheduleAssignRequestDto requestDto) {
+        String key = "meeting-" + meetingUuid;
+        while (!redisRepository.lock(key)) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        try {
+            return scheduleService.assignScheduleToGuest(meetingUuid, requestDto);
+        } finally {
+            redisRepository.delete(key);
+        }
+    }
+}

--- a/src/main/java/com/dnd/jjakkak/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/dnd/jjakkak/domain/schedule/service/ScheduleService.java
@@ -75,6 +75,13 @@ public class ScheduleService {
     @Transactional
     public ScheduleAssignResponseDto assignScheduleToGuest(String meetingUuid, ScheduleAssignRequestDto requestDto) {
 
+
+        // 이미 모임의 인원이 다 찼는가? (400 Bad Request)
+        if (meetingRepository.checkMeetingFull(meetingUuid)) {
+            throw new MeetingFullException();
+        }
+
+
         // meetingId로 할당되지 않은 schedule 조회
         Schedule schedule = scheduleRepository.findNotAssignedScheduleByMeetingUuid(meetingUuid)
                 .orElseThrow(ScheduleNotFoundException::new);
@@ -100,6 +107,11 @@ public class ScheduleService {
      */
     @Transactional
     public void assignScheduleToMember(Long memberId, String meetingUuid, ScheduleAssignRequestDto requestDto) {
+
+        // 이미 모임의 인원이 다 찼는가? (400 Bad Request)
+        if (meetingRepository.checkMeetingFull(meetingUuid)) {
+            throw new MeetingFullException();
+        }
 
         // meetingId로 할당되지 않은 schedule 조회
         Member member = memberRepository.findById(memberId)
@@ -257,11 +269,6 @@ public class ScheduleService {
         // 이미 할당된 일정인가? (409 Conflict)
         if (Boolean.TRUE.equals(schedule.getIsAssigned())) {
             throw new ScheduleAlreadyAssignedException();
-        }
-
-        // 이미 모임의 인원이 다 찼는가? (400 Bad Request)
-        if (meetingRepository.checkMeetingFull(schedule.getMeeting().getMeetingId())) {
-            throw new MeetingFullException();
         }
 
         // 닉네임 변경

--- a/src/test/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryTest.java
@@ -126,7 +126,7 @@ class MeetingRepositoryTest {
         em.persist(schedule2);
 
         // when
-        boolean isFull = meetingRepository.checkMeetingFull(testMeeting.getMeetingId());
+        boolean isFull = meetingRepository.checkMeetingFull(testMeeting.getMeetingUuid());
 
         // then
         assertFalse(isFull);

--- a/src/test/java/com/dnd/jjakkak/domain/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/dnd/jjakkak/domain/schedule/controller/ScheduleControllerTest.java
@@ -4,6 +4,7 @@ import com.dnd.jjakkak.config.AbstractRestDocsTest;
 import com.dnd.jjakkak.config.JjakkakMockUser;
 import com.dnd.jjakkak.domain.meeting.exception.MeetingNotFoundException;
 import com.dnd.jjakkak.domain.schedule.ScheduleDummy;
+import com.dnd.jjakkak.domain.schedule.facade.ScheduleFacade;
 import com.dnd.jjakkak.domain.schedule.service.ScheduleService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +39,9 @@ class ScheduleControllerTest extends AbstractRestDocsTest {
 
     @MockBean
     ScheduleService scheduleService;
+
+    @MockBean
+    ScheduleFacade scheduleFacade;
 
     @Autowired
     ObjectMapper objectMapper;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #135 

[우리 서비스에 동시성 문제는 없을까요? #129](https://github.com/dnd-side-project/dnd-11th-7-backend/discussions/129)

## 📝 작업 내용

**기존에 토큰 저장소로 사용하던 Redis(Lettuce)를 활용하여 `모임의 UUID` 를 통해 락을 거는 방식을 사용하였습니다.**


동시성 제어가 되지 않는 상황에서 여러 사용자가 동시에 일정을 할당을 시도했을 때 발생하는 문제를 해결하였습니다.

물론 Spin Lock 방식으로 인해 계속하여 락을 얻는 기법을 활용하여 부하가 생길 수 있습니다. 
Redisson 을 적용하여 이러한 문제를 해결할 수 있지만, 러닝 커브를 고려하여 적용 하지 않았습니다.

MySQL의 락 기법 (낙관적 락, 비관적 락, 네임드 락)도 고려했으나, 락 설정으로 인해 커넥션 사용량이 증가하고 별도의 커넥션 관리를 요구하는 문제가 있습니다.

또한, 데이터베이스 이슈로 MySQL 서버가 중단될 경우 서비스에 치명적인 영향을 줄 수 있어, 이를 회피하고자 데이터베이스 락은 사용하지 않는 방식을 선택하였습니다.

## 💬 리뷰 요구사항

더 좋은 개선 방식이 있는지 궁금합니다. 
