### PR TITLE
[Fix] 일정 - URI 수정

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/dnd/jjakkak/domain/schedule/controller/ScheduleController.java
@@ -77,9 +77,9 @@ public class ScheduleController {
      * @param scheduleUuid 일정 UUID (비회원)
      * @return 200 (OK), body: 일정 응답 DTO
      */
-    @GetMapping("/guests")
+    @GetMapping("/guests/{scheduleUuid}")
     public ResponseEntity<ScheduleResponseDto> getGuestSchedule(@PathVariable("meetingUuid") String meetingUuid,
-                                                                @RequestParam("scheduleUuid") String scheduleUuid) {
+                                                                @PathVariable("scheduleUuid") String scheduleUuid) {
 
         ScheduleResponseDto responseDto = scheduleService.getGuestSchedule(meetingUuid, scheduleUuid);
         return ResponseEntity.ok(responseDto);
@@ -92,9 +92,10 @@ public class ScheduleController {
      * @param memberId    요청 회원 ID
      * @return 회원의 일정 작성 여부
      */
-    @GetMapping("/check")
+    @GetMapping("/members/check")
     public ResponseEntity<Boolean> getMemberScheduleWrite(@PathVariable("meetingUuid") String meetingUuid,
                                                           @AuthenticationPrincipal Long memberId) {
+
         return ResponseEntity.ok(scheduleService.getMemberScheduleWrite(meetingUuid, memberId));
     }
 
@@ -105,7 +106,7 @@ public class ScheduleController {
      * @param requestDto   일정 수정 요청 DTO
      * @return 200 (OK)
      */
-    @PatchMapping("/{scheduleUuid}")
+    @PatchMapping("/guests/{scheduleUuid}")
     public ResponseEntity<Void> updateGuestSchedule(@PathVariable("meetingUuid") String meetingUuid,
                                                     @PathVariable("scheduleUuid") String scheduleUuid,
                                                     @Valid @RequestBody ScheduleUpdateRequestDto requestDto) {
@@ -122,7 +123,7 @@ public class ScheduleController {
      * @param requestDto  일정 수정 요청 DTO
      * @return 200 (OK)
      */
-    @PatchMapping
+    @PatchMapping("/members")
     public ResponseEntity<Void> updateMemberSchedule(@AuthenticationPrincipal Long memberId,
                                                      @PathVariable("meetingUuid") String meetingUuid,
                                                      @Valid @RequestBody ScheduleUpdateRequestDto requestDto) {

--- a/src/main/java/com/dnd/jjakkak/global/config/security/SecurityEndpointPaths.java
+++ b/src/main/java/com/dnd/jjakkak/global/config/security/SecurityEndpointPaths.java
@@ -15,16 +15,13 @@ public class SecurityEndpointPaths {
             "/api/v1/meetings/*/times/**",
             "/api/v1/meetings/*/participants",
             "/api/v1/meetings/*/schedules/guests/**",
-            "/api/v1/meetings/*/schedules/*"
     };
 
     public static final String[] USER_LIST = {
             "/api/v1/categories",
             "/api/v1/members/**",
             "/api/v1/meetings",
-            "/api/v1/meetings/*/schedules/members",
-            "/api/v1/meetings/*/schedules",
-            "/api/v1/meetings/*/schedules/check"
+            "/api/v1/meetings/*/schedules/members/**",
     };
 
     public static final String[] ADMIN_LIST = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #143 

## 📝 작업 내용

일정 컨트롤러를 2가지 계층으로 나누었습니다.

- 회원: `/members + @`
- 비회원: `/guests + @`

나눈 이유는, JWT Filter 를 처리할 때 일관성이 있지 않아, 생각했던 방식대로 동작하지 않는 경우가 존재하였습니다.
또한, 추후에 API가 추가되더라도 오류가 발생하지 않도록 분리하였습니다.


## 💬 리뷰 요구사항

X