### PR TITLE
[Fix] 모임 일정 전체보기 (익명)

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
@@ -162,20 +162,26 @@ public class MeetingRepositoryImpl extends QuerydslRepositorySupport implements 
                 .select(dateOfSchedule.dateOfScheduleRank.count())
                 .fetchCount();
 
+        // 3. 익명 모임이 아닌 경우, 일정을 할당한 사용자의 닉네임 조회 후 추가
+        Boolean isAnonymous = from(meeting)
+                .where(meeting.meetingUuid.eq(uuid))
+                .select(meeting.isAnonymous)
+                .fetchOne();
 
-        // 3. 닉네임 조회
-        for (MeetingTime meetingTime : meetingTimeList) {
-            List<String> nicknames = from(dateOfSchedule)
-                    .join(dateOfSchedule.schedule, schedule)
-                    .join(schedule.meeting, meeting)
-                    .where(meeting.meetingUuid.eq(uuid)
-                            .and(dateOfSchedule.dateOfScheduleStart.eq(meetingTime.getStartTime()))
-                            .and(dateOfSchedule.dateOfScheduleEnd.eq(meetingTime.getEndTime()))
-                            .and(schedule.assignedAt.loe(requestTime)))
-                    .select(schedule.scheduleNickname)
-                    .fetch();
+        if (Boolean.FALSE.equals(isAnonymous)) {
+            for (MeetingTime meetingTime : meetingTimeList) {
+                List<String> nicknames = from(dateOfSchedule)
+                        .join(dateOfSchedule.schedule, schedule)
+                        .join(schedule.meeting, meeting)
+                        .where(meeting.meetingUuid.eq(uuid)
+                                .and(dateOfSchedule.dateOfScheduleStart.eq(meetingTime.getStartTime()))
+                                .and(dateOfSchedule.dateOfScheduleEnd.eq(meetingTime.getEndTime()))
+                                .and(schedule.assignedAt.loe(requestTime)))
+                        .select(schedule.scheduleNickname)
+                        .fetch();
 
-            meetingTime.addMemberNames(nicknames);
+                meetingTime.addMemberNames(nicknames);
+            }
         }
 
         // 4. PageInfo 생성


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #157 

## 📝 작업 내용

모임이 익명(isAnonymous)인 경우에도 사용자의 이름이 보이는 오류를 수정하였습니다.

_MeetingRepositoryImpl.java_
```java
        // 3. 익명 모임이 아닌 경우, 일정을 할당한 사용자의 닉네임 조회 후 추가
        Boolean isAnonymous = from(meeting)
                .where(meeting.meetingUuid.eq(uuid))
                .select(meeting.isAnonymous)
                .fetchOne();

        if (Boolean.FALSE.equals(isAnonymous)) {
            for (MeetingTime meetingTime : meetingTimeList) {
                List<String> nicknames = from(dateOfSchedule)
                        .join(dateOfSchedule.schedule, schedule)
                        .join(schedule.meeting, meeting)
                        .where(meeting.meetingUuid.eq(uuid)
                                .and(dateOfSchedule.dateOfScheduleStart.eq(meetingTime.getStartTime()))
                                .and(dateOfSchedule.dateOfScheduleEnd.eq(meetingTime.getEndTime()))
                                .and(schedule.assignedAt.loe(requestTime)))
                        .select(schedule.scheduleNickname)
                        .fetch();

                meetingTime.addMemberNames(nicknames);
            }
        }
```

익명이 아닌 경우에만 닉네임을 조회하여 입력한 사람의 정보를 가져옵니다. 
