### PR TITLE
[Fix] 모임 조회 - 익명 응답

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingTime.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingTime.java
@@ -33,4 +33,15 @@ public class MeetingTime {
     public void addMemberNames(List<String> memberNames) {
         this.memberNames.addAll(memberNames);
     }
+
+    public void setAnonymous() {
+
+        List<String> anonymous = new ArrayList<>();
+        for (int i = 1; i <= memberNames.size(); i++) {
+            anonymous.add("익명" + i);
+        }
+
+        this.memberNames.clear();
+        this.memberNames.addAll(anonymous);
+    }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
@@ -4,10 +4,7 @@ import com.dnd.jjakkak.domain.category.entity.Category;
 import com.dnd.jjakkak.domain.category.exception.CategoryNotFoundException;
 import com.dnd.jjakkak.domain.category.repository.CategoryRepository;
 import com.dnd.jjakkak.domain.meeting.dto.request.MeetingCreateRequestDto;
-import com.dnd.jjakkak.domain.meeting.dto.response.MeetingCreateResponseDto;
-import com.dnd.jjakkak.domain.meeting.dto.response.MeetingInfoResponseDto;
-import com.dnd.jjakkak.domain.meeting.dto.response.MeetingParticipantResponseDto;
-import com.dnd.jjakkak.domain.meeting.dto.response.MeetingTimeResponseDto;
+import com.dnd.jjakkak.domain.meeting.dto.response.*;
 import com.dnd.jjakkak.domain.meeting.entity.Meeting;
 import com.dnd.jjakkak.domain.meeting.exception.MeetingNotFoundException;
 import com.dnd.jjakkak.domain.meeting.exception.MeetingUnauthorizedException;
@@ -173,7 +170,16 @@ public class MeetingService {
             throw new MeetingNotFoundException();
         }
 
-        return meetingRepository.getMeetingTimes(uuid, pageable, requestTime);
+        PagedResponse<MeetingTimeResponseDto> meetingTimes = meetingRepository.getMeetingTimes(uuid, pageable, requestTime);
+
+        if (Boolean.TRUE.equals(meetingTimes.getData().getIsAnonymous())) {
+            List<MeetingTime> meetingTimeList = meetingTimes.getData().getMeetingTimeList();
+            for (MeetingTime meetingTime : meetingTimeList) {
+                meetingTime.setAnonymous();
+            }
+        }
+
+        return meetingTimes;
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #157 

## 📝 작업 내용

Repository 에서 모임 익명 여부에 상관없이 조회 후 Service Layer에서 '익명'일 경우 회원 닉네임을 수정하는 방식으로 변경하였습니다. 

