### PR TITLE
[FEAT] 모임 참가자 조회 - 익명화 

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingParticipantResponseDto.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/dto/response/MeetingParticipantResponseDto.java
@@ -30,10 +30,14 @@ public class MeetingParticipantResponseDto {
         this.participantInfoList.addAll(participantInfoList);
     }
 
+    public void anonymizeNickname() {
+        this.participantInfoList.forEach(ParticipantInfo::changeNicknameToAnonymous);
+    }
+
     @Getter
     public static class ParticipantInfo {
 
-        private final String nickname;
+        private String nickname;
         private final Boolean isAssigned;
         private final Boolean isLeader;
 
@@ -41,6 +45,10 @@ public class MeetingParticipantResponseDto {
             this.nickname = nickname;
             this.isAssigned = isAssigned;
             this.isLeader = isLeader != null && isLeader;
+        }
+
+        public void changeNicknameToAnonymous() {
+            this.nickname = "익명";
         }
     }
 }

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
@@ -17,7 +17,6 @@ import com.dnd.jjakkak.domain.member.dto.response.MemberResponseDto;
 import com.dnd.jjakkak.domain.member.entity.Member;
 import com.dnd.jjakkak.domain.member.exception.MemberNotFoundException;
 import com.dnd.jjakkak.domain.member.repository.MemberRepository;
-import com.dnd.jjakkak.domain.refreshtoken.service.RefreshTokenService;
 import com.dnd.jjakkak.domain.schedule.service.ScheduleService;
 import com.dnd.jjakkak.global.common.PagedResponse;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +45,6 @@ public class MeetingService {
     private final MeetingMemberRepository meetingMemberRepository;
     private final MemberRepository memberRepository;
     private final MeetingMemberService meetingMemberService;
-    private final RefreshTokenService refreshTokenService;
 
     /**
      * 모임을 생성하는 메서드입니다.

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/service/MeetingService.java
@@ -17,6 +17,7 @@ import com.dnd.jjakkak.domain.member.dto.response.MemberResponseDto;
 import com.dnd.jjakkak.domain.member.entity.Member;
 import com.dnd.jjakkak.domain.member.exception.MemberNotFoundException;
 import com.dnd.jjakkak.domain.member.repository.MemberRepository;
+import com.dnd.jjakkak.domain.refreshtoken.service.RefreshTokenService;
 import com.dnd.jjakkak.domain.schedule.service.ScheduleService;
 import com.dnd.jjakkak.global.common.PagedResponse;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +46,7 @@ public class MeetingService {
     private final MeetingMemberRepository meetingMemberRepository;
     private final MemberRepository memberRepository;
     private final MeetingMemberService meetingMemberService;
+    private final RefreshTokenService refreshTokenService;
 
     /**
      * 모임을 생성하는 메서드입니다.
@@ -195,7 +197,13 @@ public class MeetingService {
             throw new MeetingNotFoundException();
         }
 
-        return meetingRepository.getParticipant(uuid);
+        MeetingParticipantResponseDto response = meetingRepository.getParticipant(uuid);
+
+        if (Boolean.TRUE.equals(response.getIsAnonymous())) {
+            response.anonymizeNickname();
+        }
+
+        return response;
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #164 

## 📝 작업 내용

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fcfe1728-4431-4ca6-a6e8-e36eb6b64205" />

모임의 참가자를 조회할 때 `isAnonymous` 값을 확인한 후 **TRUE** 일 경우, '익명' 으로 익명화하는 것으로 변경하였습니다 .
