### PR TITLE
[REFACTOR] Querydsl - fetchCount 수정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,10 +52,10 @@ dependencies {
     // oauth2 dependency
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-    // jwt token
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+    // JWT dependencies
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // Spring REST Docs
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
@@ -155,12 +155,17 @@ public class MeetingRepositoryImpl extends QuerydslRepositorySupport implements 
         long totalElements = from(dateOfSchedule)
                 .join(dateOfSchedule.schedule, schedule)
                 .join(schedule.meeting, meeting)
-                .where(meeting.meetingUuid.eq(uuid)
-                        .and(schedule.assignedAt.isNotNull())
-                        .and(schedule.assignedAt.loe(requestTime)))
-                .groupBy(dateOfSchedule.dateOfScheduleStart, dateOfSchedule.dateOfScheduleEnd)
+                .where(
+                        meeting.meetingUuid.eq(uuid),
+                        schedule.assignedAt.isNotNull(),
+                        schedule.assignedAt.loe(requestTime)
+                )
+                .groupBy(
+                        dateOfSchedule.dateOfScheduleStart,
+                        dateOfSchedule.dateOfScheduleEnd
+                )
                 .select(dateOfSchedule.dateOfScheduleRank.count())
-                .fetchCount();
+                .fetchOne();
 
         // 3. 일정을 할당한 사용자의 닉네임 조회 후 추가
         for (MeetingTime meetingTime : meetingTimeList) {
@@ -246,9 +251,12 @@ public class MeetingRepositoryImpl extends QuerydslRepositorySupport implements 
         return from(schedule)
                 .join(schedule.meeting, meeting)
                 .join(schedule.member, member)
-                .where(meeting.meetingUuid.eq(meetingUuid)
-                        .and(member.memberId.eq(memberId)))
-                .fetchCount() > 0;
+                .where(
+                        meeting.meetingUuid.eq(meetingUuid),
+                        member.memberId.eq(memberId)
+                )
+                .select(schedule.scheduleId)
+                .fetchFirst() != null;
 
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #166 

## 📝 작업 내용

`deprecated` 된 `fetchCount()` 를 사용하고 있는 방식 수정

- totalCount: count() + fetchOne()
- boolean: fetchFirst != null 
