### PR TITLE
[REFACTOR] Querydsl - fetchCount 수정

### DIFF
--- a/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
+++ b/src/main/java/com/dnd/jjakkak/domain/meeting/repository/MeetingRepositoryImpl.java
@@ -165,7 +165,8 @@ public class MeetingRepositoryImpl extends QuerydslRepositorySupport implements 
                         dateOfSchedule.dateOfScheduleEnd
                 )
                 .select(dateOfSchedule.dateOfScheduleRank.count())
-                .fetchOne();
+                .fetch()
+                .size();
 
         // 3. 일정을 할당한 사용자의 닉네임 조회 후 추가
         for (MeetingTime meetingTime : meetingTimeList) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolves #166 

## 📝 작업 내용

group by 로 인해 FetchOne() 을 사용했을 경우 오류가 발생합니다. 
이로 인해, fetch() 를 통해 일정 리스트를 가져온 후 해당 일정들의 size() 를 반환하는 방식으로 변경했습니다.

